### PR TITLE
Fix query to get site entries for a specific sitemap tree

### DIFF
--- a/src/services/SitemapService.php
+++ b/src/services/SitemapService.php
@@ -215,7 +215,7 @@ class SitemapService extends Component
                     ->from('{{%elements_sites}} as elements_sites')
                     ->leftJoin('{{%sites}} as sites', 'sites.id = elements_sites.siteId')
                     ->where('[[elementId]] = ' . $entry->id)
-                    ->andWhere('elements_sites.enabled = true')
+                    ->andWhere('sites.enabled = true')
                     ->all();
             $sites = array_filter($siteEntries, function ($item) use ($currentSite) {
                 if ($item['siteId'] != $currentSite->id) {


### PR DESCRIPTION
There is an error in the site entries query that includes wrongly the entries from other sites.
This throws an error when sites are not enabled for the frontend and not fully developed.