### PR TITLE
Fix for products in case of multisites

### DIFF
--- a/src/services/SitemapService.php
+++ b/src/services/SitemapService.php
@@ -338,7 +338,6 @@ class SitemapService extends Component
                     if ($productTypeSite->siteId == $site->id && $productTypeSite->hasUrls) {
                         return true;
                     }
-                    return false;
                 }
             } else {
                 return false;


### PR DESCRIPTION
In case of multisites, the sitemap for the products does not get generated if the current site is not the first site. I've removed the line of code that returned false in the for loop.