### PR TITLE
[Composer] make composer requirements more flexible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require": {
     "craftcms/cms": "^5.0.0",
     "spatie/schema-org": "^3.0.0",
-    "openspout/openspout": "^v4.0.0"
+    "openspout/openspout": "^v4|^v5"
   },
   "require-dev": {
     "craftcms/ecs": "dev-main",


### PR DESCRIPTION
allow loading openspout 4 or 5 since they are almost equivalent and most projects will be using 5